### PR TITLE
Update installation.mdx to fix Hyperlink to Migrations page from Installation page

### DIFF
--- a/content/docs/installation.mdx
+++ b/content/docs/installation.mdx
@@ -6,7 +6,7 @@ description: A comprehensive guide for setting up Pyrodactyl using Docker
 This comprehensive guide walks you through setting up Pyrodactyl using Docker, from scratch to a fully functional system.
 
 <Callout type="note">
-  The guide for migration has moved to a [new page](migration).
+  The guide for migration has moved to a [new page](migrations).
 </Callout>
 
 <Callout type="info">


### PR DESCRIPTION
"The guide for migration has moved to a new page." led to *pyrodactyl.dev/docs/migration* not *pyrodactyl.dev/docs/migrations*