### PR TITLE
added a badege with version number for latest on update guide - Update native-update.mdx

### DIFF
--- a/content/docs/migrations/native-update.mdx
+++ b/content/docs/migrations/native-update.mdx
@@ -5,6 +5,10 @@ description: Guide for updating your native Pyrodactyl installation and resolvin
 
 ## Updating Your Native Installation
 
+Newest release version: 
+
+![Pyrodactyl Latest Release](https://img.shields.io/github/v/release/pyrohost/pyrodactyl?style=for-the-badge)
+
 <Callout type="warn">
   Before proceeding with any updates, make sure to back up your database and
   panel files.


### PR DESCRIPTION
- Added a badge showing the latest Pyrodactyl release version from GitHub

to show the newest version number on releases the badge does should be changed to better match colours, but to show newest version for update to cross compare if panel is already updated, for newer users to know newest