### PR TITLE
Adds Docs for Blueprint Support

### DIFF
--- a/content/docs/blueprint/index.mdx
+++ b/content/docs/blueprint/index.mdx
@@ -1,0 +1,31 @@
+---
+title: Blueprint Documentation
+description: A fork of Blueprint Framework that works for Pyrodactyl
+---
+
+<Callout type="warning">
+This fork is not maintained by Pyro Inc. Although there is `#blueprint-support` channel, please direction any questions, issues, or problems to @flyingcopper within the channel as I am the main maintainer of the project and to not interfere with Pyro maintainers.
+</Callout>
+
+## Dependencies
+<Tabs items={["Ubuntu"]}>
+    <Tab value="Ubuntu">
+        ```bash
+        # Install dependencies
+        sudo apt install -y ca-certificates curl git gnupg unzip wget zip
+
+        # Add Node.js apt repository
+        sudo mkdir -p /etc/apt/keyrings
+        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+        sudo apt update
+        sudo apt install -y nodejs
+
+        # Install yarn
+        npm i -g yarn
+        yarn install
+        ```
+    </Tab>
+</Tabs>
+
+Now follow the instructions for your installation method.

--- a/content/docs/blueprint/installation/index.mdx
+++ b/content/docs/blueprint/installation/index.mdx
@@ -1,0 +1,33 @@
+---
+title: Installation
+description: Learn how to get started with Blueprint
+---
+
+<Callout type='warning'>
+More installation instructions will be added in the future. For now, there is a native installation guide.
+</Callout>
+
+<Cards>
+    <Card
+        title="Native Installation"
+        href="/docs/blueprint/installation/native-install"
+    >
+        Setup Blueprint on Bare metal from Scratch
+    </Card>
+</Cards>
+
+## Coming Soon
+<Cards>
+    <Card
+        title="Fresh Installation"
+        href="#"
+    >
+        Setup Blueprint using Docker from scratch to a fully functional system.
+    </Card>
+    <Card
+        title="Install on Dokploy"
+        href="#"
+    >
+        Setup Blueprint using more specific guides made by the community.
+    </Card>
+</Cards>

--- a/content/docs/blueprint/installation/native-install.mdx
+++ b/content/docs/blueprint/installation/native-install.mdx
@@ -1,0 +1,60 @@
+---
+title: Native Install
+description: Learn how to get started with Blueprint on Bare Metal
+---
+
+After making sure to install the dependencies, you can now follow the next steps!
+
+<Callout type='info'>
+It is highly recommended that you use the offical Blueprint page to configure your environment variables.
+Additionally, most of the instructions on this page are based on the offical Blueprint page which typically means that the offical page is more up to date.
+Those instructions can all be found [here](https://blueprint.zip/guides/admin/install).
+</Callout>
+
+## Step 1 - Define Pyrodactyl Directory
+First you need to set an environment variable for the blueprint script to use.
+```bash
+# Use this command to set a $PYRODACTYL_DIRECTORY variable
+# for use later in this guide.
+export PYRODACTYL_DIRECTORY=/var/www/pyrodactyl
+```
+
+## Step 2 - Download & Install Blueprint
+```bash
+# Navigate to your Pyrodactyl directory
+cd $PYRODACTYL_DIRECTORY
+
+# Download and unzip Blueprint's latest release
+wget "$(curl -s https://api.github.com/repos/pyrodactyl-oss/blueprint-framework/releases/latest | grep 'browser_download_url' | cut -d '"' -f 4)" -O $PYRODACTYL_DIRECTORY/release.zip
+unzip -o release.zip
+```
+
+## Step 3 - Configure Blueprint
+```bash
+# Creates a .blueprintrc file in your Pyrodactyl directory
+touch $PYRODACTYL_DIRECTORY/.blueprintrc
+```
+Now modify `$WEBUSER`, `$OWNERSHIP` and `$USERSHELL` to match the values of your environment. Here is the example from the offical Blueprint page.
+```bash
+# Writes data to your .blueprintrc file
+echo \
+'WEBUSER="www-data";
+OWNERSHIP="www-data:www-data";
+USERSHELL="/bin/bash";' > $PYRODACTYL_DIRECTORY/.blueprintrc
+```
+
+<Callout type='info'>
+If you are confused about the values of these variables, please refer to the [official Blueprint page](https://blueprint.zip/guides/admin/install#configure-blueprint) for more information.
+</Callout>
+
+## Step 4 - Run Blueprint
+All thats left now is to run `blueprint.sh` to finalize the installation.
+```bash
+# Give blueprint.sh execute permissions
+chmod +x $PYRODACTYL_DIRECTORY/blueprint.sh
+
+# Run blueprint.sh
+bash $PYRODACTYL_DIRECTORY/blueprint.sh
+```
+
+Now you should be able to enjoy Blueprint and download plugins to your heart's desire!

--- a/content/docs/blueprint/meta.json
+++ b/content/docs/blueprint/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Blueprint",
+  "description": "Docs for the Blueprint port",
+  "icon": "blueprint",
+  "root": true
+}

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -1,3 +1,3 @@
 {
-  "pages": ["pyrodactyl", "elytra"]
+  "pages": ["pyrodactyl", "elytra", "blueprint"]
 }

--- a/src/components/ui/BlueprintLogo.tsx
+++ b/src/components/ui/BlueprintLogo.tsx
@@ -1,0 +1,11 @@
+export default function BlueprintLogo() {
+    return (
+        <svg viewBox="0 0 3 3" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor">
+            <rect x="1" y="0" width="1" height="1"></rect>
+            <rect x="0" y="1" width="1" height="1"></rect>
+            <rect x="2" y="1" width="1" height="1"></rect>
+            <rect x="1" y="2" width="1" height="1"></rect>
+            <rect x="2" y="2" width="1" height="1"></rect>
+        </svg>
+    );
+};

--- a/src/lib/source.ts
+++ b/src/lib/source.ts
@@ -3,21 +3,29 @@ import { loader } from 'fumadocs-core/source';
 import { createElement } from 'react';
 import { icons } from 'lucide-react';
 import PyrodactylLogo from '@/components/ui/PyrodactylLogo';
+import BlueprintLogo from '@/components/ui/BlueprintLogo';
+import { Bird } from "lucide-react"
 
 // `loader()` also assign a URL to your pages
 // See https://fumadocs.vercel.app/docs/headless/source-api for more info
 export const source = loader({
-  baseUrl: '/docs',
-  source: docs.toFumadocsSource(),
-  icon(icon) {
-    if (!icon) {
-      return
-    }
-    if (icon == "pyrodactyl") {
-      return PyrodactylLogo();
-    }
+    baseUrl: '/docs',
+    source: docs.toFumadocsSource(),
+    icon(icon) {
+        if (!icon) {
+            return
+        }
+        switch (icon) {
+            case 'pyrodactyl':
+                return PyrodactylLogo();
+            case 'blueprint':
+                return BlueprintLogo();
+            case 'elytra':
+                // WARNING: Temp fix until we have a proper icon for elytra
+                return createElement(Bird);
+        }
 
-    if (icon in icons) return createElement(icons[icon as keyof typeof icons]);
-  },
+        if (icon in icons) return createElement(icons[icon as keyof typeof icons]);
+    },
 });
 


### PR DESCRIPTION
The [Blueprint Fork](https://github.com/pyrodactyl-oss/blueprint-framework) is officially working on Pyro Panel. The fork is updated to the most recent version of the official blueprint repo. 

## This merge adds a few things:
1. Fixes how Icons are handled for the dropdown menu, by making use of switch statements. (Also gives Elytra a temporary icon until one is created)
2. Adds Native install docs for Blueprint.